### PR TITLE
Support 128 cores

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -6,21 +6,29 @@
 
 body {
   background: #0f0f0f;
+  margin: 0;
+}
+
+.procs {
+  display: flex;
+  flex-flow: row wrap;
+  max-width: 100vw;
+  max-height: 100vh;
+  padding: 0;
 }
 
 .bar {
   background: #264653;
   color: white;
 
-  width: 20em;
-  height: 2em;
-  margin: .5em;
-
   display: flex;
   align-items: center;
   justify-content: center;
 
   position: relative;
+  width: 6.25vw;
+  height: 12.5vh;
+  padding: 0;
 }
 
 .bar label {
@@ -38,9 +46,9 @@ body {
   top: 0;
   bottom: 0;
 
-	transition: width 0.2s;
+	transition: width .5s;
 }
 
 .bar, .bar-inner {
-  border-radius: 4px;
+  border-radius: 10px;
 }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,43 +1,74 @@
-import { h, render } from "https://unpkg.com/preact?module";
 import htm from "https://unpkg.com/htm?module";
+import {
+  useEffect,
+  useState,
+} from "https://unpkg.com/preact@latest/hooks/dist/hooks.module.js?module";
+import { h, render } from "https://unpkg.com/preact@latest?module";
 
 const html = htm.bind(h);
 
-function App(props) {
-  return html`
-    <div>
-      ${props.cpus.map((cpu) => {
-        return html`<div class="bar">
-          <div class="bar-inner" style="width: ${cpu}%"></div>
-          <label>${cpu.toFixed(2)}%</label>
-        </div>`;
-      })}
-    </div>
-  `;
+function percentageToColor(percentage, maxHue = 0, minHue = 120) {
+  const hue = 120 - percentage;
+  return `hsl(${hue}, 100%, 50%)`;
 }
 
-let i = 0;
-
-// let update = async () => {
-//   let response = await fetch("/api/cpus");
-//   if (response.status !== 200) {
-//     throw new Error(`HTTP error! status: ${response.status}`);
-//   }
-
-//   let json = await response.json();
-//   render(html`<${App} cpus=${json}></${App}>`, document.body);
-// };
-
-// update();
-// setInterval(update, 200);
-
-let url = new URL("/realtime/cpus", window.location.href);
-// http => ws
-// https => wss
-url.protocol = url.protocol.replace("http", "ws");
-
-let ws = new WebSocket(url.href);
-ws.onmessage = (ev) => {
-  let json = JSON.parse(ev.data);
-  render(html`<${App} cpus=${json}></${App}>`, document.body);
+const map = (x, in_min, in_max, out_min, out_max) => {
+  return ((x - in_min) * (out_max - out_min)) / (in_max - in_min) + out_min;
 };
+
+const mapper = (range) => {
+  return (x) => {
+    return map(x, 0, 100, 0, range);
+  };
+};
+
+const m = mapper(120);
+
+function Proc({ cpu, total }) {
+  return html`<div
+    class="bar-inner"
+    style="
+      width: ${cpu}%;
+      opacity: ${cpu / 100};
+      background: ${percentageToColor(m(cpu))}
+    "
+  ></div>`;
+}
+
+function CpuGraph({ cpus }) {
+  if (cpus) {
+    return html`
+      <div class="procs">
+        ${cpus
+          .map((cpu, i) => ({ cpu, i }))
+          .sort((a, b) => (a.cpu < b.cpu ? 1 : -1))
+          .map(({ cpu, i }) => {
+            return html`<div class="bar">
+              <${Proc} cpu=${cpu} total=${cpus.length} />
+              <label>${i}</label>
+            </div>`;
+          })}
+      </div>
+    `;
+  }
+}
+
+function App() {
+  let url = new URL("/realtime/cpus", window.location.href);
+  url.protocol = url.protocol.replace("http", "ws");
+  const [cpus, setCpus] = useState();
+  useEffect(() => {
+    let ws = new WebSocket(url.href);
+    ws.onmessage = (ev) => {
+      let cpusUpdate = JSON.parse(ev.data);
+      setCpus(cpusUpdate);
+    };
+    return () => {
+      ws.close();
+    };
+  }, []);
+
+  return html`<${CpuGraph} cpus=${cpus}></${CpuGraph}>`;
+}
+
+render(html`<${App} />`, document.body);

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,8 +90,8 @@ async fn realtime_cpus_stream(app_state: AppState, mut ws: WebSocket) {
     let mut rx = app_state.tx.subscribe();
 
     while let Ok(msg) = rx.recv().await {
-        ws.send(Message::Text(serde_json::to_string(&msg).unwrap()))
-            .await
-            .unwrap();
+        let _ = ws
+            .send(Message::Text(serde_json::to_string(&msg).unwrap()))
+            .await;
     }
 }


### PR DESCRIPTION
thank you for this cool utility @fasterthanlime ! I use it locally to monitor SSH coding on a super fast box w/256GB Ram / 64 Cores.
Here is what I changed:
- [ ] color from green -> red  clear -> solid to indicate core usage
- [ ] sort core layout based on usage
- [ ] squares

<img width="1887" alt="image" src="https://user-images.githubusercontent.com/35079898/223535789-4013dd26-4902-44a0-80a2-4c22f0201a62.png">


# Todo
- [ ] make squares scale in regards to core count