### PR TITLE
Upgrade sysinfo to fix CPU usage on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,9 +815,9 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sysinfo"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a81bbc26c485910df47772df6bbcdb417036132caa9e51e29d2e39c4636d4e"
+checksum = "d3e847e2de7a137c8c2cede5095872dbb00f4f9bf34d061347e36b43322acd56"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2021"
 [dependencies]
 axum = { version = "0.6.9", features = ["macros", "ws"] }
 serde_json = "1.0.93"
-sysinfo = "0.28.1"
+sysinfo = "0.28.2"
 tokio = { version = "1.25.0", features = ["full"] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }


### PR DESCRIPTION
Hi, this PR just bumps `sysinfo` from 0.28.1 to 0.28.2. This [fixes a bug](https://github.com/GuillaumeGomez/sysinfo/pull/946) you noticed in the video, where the CPU usage never goes to zero for any given core.

In a lucky coincidence, I was dealing with this bug shortly before watching your video: https://github.com/GuillaumeGomez/sysinfo/issues/945

Thanks for publishing this video+code (and everything else)!

### Before:

![image](https://user-images.githubusercontent.com/26268125/225403409-8bfcb108-0b38-4e94-b75f-a0fefde30ed2.png)

### After:

![image](https://user-images.githubusercontent.com/26268125/225403434-c0ecd7b7-8aaf-41f0-83ec-91e3589cfb32.png)
